### PR TITLE
fix filtered markers being visible after spiderifying clusters

### DIFF
--- a/LeafletSpiderfier.ts
+++ b/LeafletSpiderfier.ts
@@ -38,7 +38,9 @@ var PruneClusterLeafletSpiderfier = ((<any>L).Layer ? (<any>L).Layer : L.Class).
 
 	Spiderfy: function(data) {
 		this.Unspiderfy();
-		var markers = data.markers;
+		var markers = data.markers.filter(function(marker) {
+			return !marker.filtered;
+		});
 
 		this._currentCenter = data.center;
 


### PR DESCRIPTION
Currently all markers in a cluster are rendered by Spiderfy even if they were filtered.
