### PR TITLE
Added check to see if _icon exists before acting on it

### DIFF
--- a/LeafletAdapter.ts
+++ b/LeafletAdapter.ts
@@ -479,7 +479,7 @@ var PruneClusterForLeaflet = ((<any>L).Layer ? (<any>L).Layer : L.Class).extend(
 
 			// Fading in transition
 			// (disabled by default with no-anim)
-			L.DomUtil.addClass(creationMarker._icon, "no-anim");
+			if(creationMarker._icon) L.DomUtil.addClass(creationMarker._icon, "no-anim");
 			creationMarker.setOpacity(0);
 			opacityUpdateList.push(creationMarker);
 
@@ -495,7 +495,7 @@ var PruneClusterForLeaflet = ((<any>L).Layer ? (<any>L).Layer : L.Class).extend(
 		window.setTimeout(() => {
 			for (i = 0, l = opacityUpdateList.length; i < l; ++i) {
 				var m = opacityUpdateList[i];
-				L.DomUtil.removeClass(m._icon, "no-anim");
+				if(m._icon) L.DomUtil.removeClass(m._icon, "no-anim");
 				m.setOpacity(1);
 			}
 		}, 1);


### PR DESCRIPTION
The latest change to add/remove the no-anim css class is breaking my project.  This is occurring because we are also trying to cluster polygons as well as markers, and polygons don't have icons.
