### PR TITLE
Fix issues at bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,8 +1,22 @@
 {
   "name": "PruneCluster",
-  "version": "0.10.1",
   "devDependencies": {
     "DefinitelyTyped": "*",
     "leaflet-dist": "~0.7.2"
+  },
+  "ignore": [
+    "*.ts",
+    "*.md",
+    "package.json",
+    "meteor",
+    "examples",
+    "Gruntfile.js",
+    "LICENSE",
+    "bower.json"
+  ],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/SINTEF-9012/PruneCluster.git"
   }
 }


### PR DESCRIPTION
- Remove deprecated `version` https://github.com/bower/spec/blob/master/json.md#version
- Add `ignore` https://github.com/bower/spec/blob/master/json.md#ignore
- Add `main`  https://github.com/bower/spec/blob/master/json.md#main
- Add `license` and `repository` 

Because now when installing with bower I get:
```
bower PruneCluster#~1.1.0                      mismatch Version declared in the json (0.10.1) is different than the resolved one (1.1.0)
bower PruneCluster#~1.1.0                  invalid-meta PruneCluster is missing "main" entry in bower.json
bower PruneCluster#~1.1.0                  invalid-meta PruneCluster is missing "ignore" entry in bower.json
```