### PR TITLE
Fixed bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,5 +21,5 @@
     "type": "git",
     "url": "https://github.com/SINTEF-9012/PruneCluster.git"
   },
-  "main": ["./dist/LeafletStyleSheet.css", "./dist/PruneCluster.js"]
+  "main": ["dist/LeafletStyleSheet.css", "dist/PruneCluster.js"]
 }


### PR DESCRIPTION
I've faced difficulties while using PruneCluster with grunt-bower-concat, it seemed that the filepaths in "main" property were wrong, so that's the fix.