### PR TITLE
added json example

### DIFF
--- a/examples/json example/heatmap.html
+++ b/examples/json example/heatmap.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html>
+<head>
+ <title>
+  Heatmap with Leaflet
+ </title>
+ <!-- link to leaflet css --> 
+ <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.0.0-beta.2.rc.2/leaflet.css"/>
+ <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.0.0-beta.2.rc.2/leaflet.js"></script>
+ <script src="../../dist/PruneCluster.js"></script>
+ <!-- map is full width and height of device -->
+ <meta name="viewport" content="width=device-width, maximum-scale=1.0, user-scalable=no"/>
+ <!-- css --->
+ <link rel="stylesheet" href="../examples.css"/>
+ 
+</head>
+<body>
+
+ <div id="map"></div>
+<div href="#" id="size">Cluster size: <input type="range" value="160" min="35" max="500" step="1" id="sizeInput"/><span id="currentSize">160</span></div>
+<script>
+	
+	var map = L.map("map", {
+        attributionControl: false,
+        zoomControl: true
+    }).setView(new L.LatLng(28.3949, 84.1240), 15);
+
+    L.tileLayer('http://{s}.tile.osm.org/{z}/{x}/{y}.png', {
+        detectRetina: true,
+        maxNativeZoom: 17
+    }).addTo(map);
+
+    var leafletView = new PruneClusterForLeaflet(160);
+
+    var size = 10000;
+    var markers = [];
+	
+	var request = new XMLHttpRequest();
+	request.open("GET", "diwalipretty.json", false);
+	request.send(null)
+	var json = JSON.parse(request.responseText);
+	for (var a = 0; a < json.features.length; a++) {
+		var lon = json.features[a].geometry.coordinates[0];
+		var lat = json.features[a].geometry.coordinates[1];
+		if (lon != 0.0 && lat != 0.0) {
+			var marker = new PruneCluster.Marker(lat, lon);
+			markers.push(marker);
+			leafletView.RegisterMarker(marker);
+		}
+	}
+	console.log("finished parsing")
+	
+    var lastUpdate = 0;
+    window.setInterval(function () {
+	    var now = +new Date();
+	    if ((now - lastUpdate) < 400) {
+	    	return;
+	    }
+
+        for (i = 0; i < size / 2; ++i) {
+            var coef = i < size / 8 ? 10 : 1;
+            var ll = markers[i].position;
+            ll.lat += (Math.random() - 0.5) * 0.00001 * coef;
+            ll.lng += (Math.random() - 0.5) * 0.00002 * coef;
+        }
+
+        leafletView.ProcessView();
+	    lastUpdate = now;
+    }, 500);
+
+    map.addLayer(leafletView);
+
+    var currentSizeSpan = document.getElementById('currentSize');
+
+	var updateSize = function () {
+    	leafletView.Cluster.Size = parseInt(this.value);
+		currentSizeSpan.firstChild.data = this.value;
+
+	    var now = +new Date();
+	    if ((now - lastUpdate) < 400) {
+	    	return;
+	    }
+		leafletView.ProcessView();
+		lastUpdate = now;
+	};
+    document.getElementById('sizeInput').onchange = updateSize; 
+    document.getElementById('sizeInput').oninput = updateSize; 
+    
+</script> 
+</body>
+</html>

--- a/examples/json example/instructions.rtf
+++ b/examples/json example/instructions.rtf
@@ -1,0 +1,13 @@
+{\rtf1\ansi\ansicpg1252\cocoartf1504\cocoasubrtf600
+{\fonttbl\f0\fswiss\fcharset0 Helvetica;}
+{\colortbl;\red255\green255\blue255;}
+{\*\expandedcolortbl;\csgray\c100000;}
+\margl1440\margr1440\vieww10800\viewh8400\viewkind0
+\pard\tx720\tx1440\tx2160\tx2880\tx3600\tx4320\tx5040\tx5760\tx6480\tx7200\tx7920\tx8640\pardirnatural\partightenfactor0
+
+\f0\fs24 \cf0 Instructions for using this demo:\
+\
+1. You need to unzip the json file for the demo html to work\
+2. This json file is massive and has over 3,000,000 features in it.  It takes my MacBook about 1 minute to load the web page - but once loaded, it works seamlessly.  \
+3. If you\'92d like to switch it out for your own file, edit the html accordingly.  The code is quite simple :) and smaller json files will work far more quickly than my massive one.\
+4. In case you\'92re curious, the json file included is the complete history of all \'93nodes\'94 mapped in Open Street Maps until 2015 in Nepal.  Enjoy!}


### PR DESCRIPTION
I added an example of how to load basic Point features from a JSON file into a PruneCluster Leaflet map.  In order for my example to work you must unzip the zip'd JSON file as it is quite large.  The benefit is that this also demonstrates the capacities of PruneCluster for large data - in this case, with a JSON file with over 3,000,000 items.