### PR TITLE
Make 200+ markers with shared coords spiderify

### DIFF
--- a/LeafletAdapter.ts
+++ b/LeafletAdapter.ts
@@ -148,7 +148,7 @@ var PruneClusterForLeaflet = ((<any>L).Layer ? (<any>L).Layer : L.Class).extend(
 					}
 
 					// TODO use an option registered somewhere
-					if (markersArea.length < 200) { 
+					if (markersArea.length < 200 || zoomLevelAfter >= this._map.getMaxZoom()) { 
 
 						// Send an event for the LeafletSpiderfier
 						this._map.fire('overlappingmarkers', {
@@ -158,7 +158,7 @@ var PruneClusterForLeaflet = ((<any>L).Layer ? (<any>L).Layer : L.Class).extend(
 							marker: m
 						});
 
-					} else if (zoomLevelAfter < this._map.getMaxZoom()) {
+					} else {
 						zoomLevelAfter++;
 					}
 


### PR DESCRIPTION
If over 200 markers shared coordinates they would not separate. Now when the zoom limit is hit, force spiderify.