### PR TITLE
Fix possible npe

### DIFF
--- a/LeafletSpiderfier.ts
+++ b/LeafletSpiderfier.ts
@@ -172,10 +172,11 @@ var PruneClusterLeafletSpiderfier = ((<any>L).Layer ? (<any>L).Layer : L.Class).
 			this._currentMarkers[i].setLatLng(this._currentCenter).setOpacity(0);
 		}
 
+		var map = this._map;
 		var markers = this._currentMarkers;
 		window.setTimeout(() => {
 			for (i = 0, l = markers.length; i < l; ++i) {
-				this._map.removeLayer(markers[i]);
+				map.removeLayer(markers[i]);
 			}
 
 		}, 300);


### PR DESCRIPTION
Stash this._map because when removing a PruneClusterForLeaflet layer, the cluster 'onRemove' sets this._map to null (which causes an npe in the setTimeout() function callback if we had a spiderfied cluster).