### PR TITLE
Add AMD support

### DIFF
--- a/AMD_footer
+++ b/AMD_footer
@@ -1,0 +1,5 @@
+    return {
+        PruneCluster: PruneCluster,
+        PruneClusterForLeaflet: PruneClusterForLeaflet
+    };
+}));

--- a/AMD_header
+++ b/AMD_header
@@ -1,0 +1,15 @@
+(function(root, factory) {
+    if(typeof define === 'function' && define.amd) {
+        define(['leaflet'], factory);
+    } else if (typeof module !== 'undefined') {
+        module.exports = factory(require('leaflet'));
+    } else {
+        if (!root.L) {
+            throw 'Leaflet must be loaded previously';
+        }
+
+        var PruneClusterModule = factory(root.L);
+        root.PruneCluster = PruneClusterModule.PruneCluster;
+        root.PruneClusterForLeaflet = PruneClusterModule.PruneClusterForLeaflet;
+    }
+}(this, function(L) {

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -8,19 +8,19 @@ module.exports = function (grunt) {
             dist: {
                 files: [{
                     src: ["dist/*.js", "dist/*.d.ts", "dist/*.css"]
-                }],
+                }]
             },
             dev: {
                 files: [{
                     src: ["build/*.js", "build/*.d.ts", "build/*.map", "build/*.css"]
-                }],
+                }]
             }
         },
         ts: {
             options: {
                 target: 'es5',
                 module: 'amd',
-                declaration: true,
+                declaration: true
             },
             dist: {
                 src: ["PruneCluster.ts", "LeafletAdapter.ts", "LeafletSpiderfier.ts"],
@@ -37,13 +37,20 @@ module.exports = function (grunt) {
                 }
             }
         },
+        concat: {
+            dist: {
+                src: ['./AMD_header', './dist/PruneCluster.js', './AMD_footer'],
+                dest: './dist/PruneCluster.amd.js'
+            }
+        },
         uglify: {
             ts: {
                 options: {
                     sourceMap: false
                 },
                 files: {
-                    'dist/PruneCluster.min.js': ['dist/PruneCluster.js']
+                    'dist/PruneCluster.min.js': ['dist/PruneCluster.js'],
+                    'dist/PruneCluster.amd.min.js': ['dist/PruneCluster.amd.js']
                 }
             }
         },
@@ -86,6 +93,7 @@ module.exports = function (grunt) {
         'clean:dist',
         'copy:dist',
         'ts:dist',
+        'concat:dist',
         'uglify'
     ]);
 
@@ -93,7 +101,7 @@ module.exports = function (grunt) {
         'clean:dev',
         'copy:dev',
         'ts:dev'
-    ])
+    ]);
 
     grunt.registerTask('build',   ['build:dev']);
     grunt.registerTask('default', ['build:dev']);

--- a/README.md
+++ b/README.md
@@ -92,6 +92,35 @@ pruneCluster.RegisterMarker(marker);
 leafletMap.addLayer(pruneCluster);
 ```
 
+#### AMD
+
+```
+npm install
+npm install -g grunt-cli
+grunt build:dist --force
+```
+
+Then, you will have files ready to use in AMD style under `dist` directory.
+
+#### Example
+
+```javascript
+// First 'PruneCluster' must be declared in your module loader, pointing to file 'dist/PruneCluster.amd.min.js'
+// (or use path to file instead)
+
+define(['PruneCluster', function(PruneClusterModule) {
+
+  var pruneCluster = new PruneClusterModule.PruneClusterForLeaflet();
+
+  ...
+  var marker = new PruneClusterModule.PruneCluster.Marker(59.8717, 11.1909);
+  pruneCluster.RegisterMarker(marker);
+  ...
+
+  leafletMap.addLayer(pruneCluster);
+});
+```
+
 ### PruneClusterForLeaflet constructor
 
 ```javascript

--- a/dist/PruneCluster.js
+++ b/dist/PruneCluster.js
@@ -928,14 +928,14 @@ var PruneClusterLeafletSpiderfier = (L.Layer ? L.Layer : L.Class).extend({
         return res;
     },
     Unspiderfy: function () {
-        var _this = this;
         for (var i = 0, l = this._currentMarkers.length; i < l; ++i) {
             this._currentMarkers[i].setLatLng(this._currentCenter).setOpacity(0);
         }
+        var map = this._map;
         var markers = this._currentMarkers;
         window.setTimeout(function () {
             for (i = 0, l = markers.length; i < l; ++i) {
-                _this._map.removeLayer(markers[i]);
+                map.removeLayer(markers[i]);
             }
         }, 300);
         this._currentMarkers = [];

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "devDependencies": {
     "grunt": "^1.0.1",
     "grunt-contrib-clean": "~1.1.0",
+    "grunt-contrib-concat": "^1.0.1",
     "grunt-contrib-copy": "~1.0.0",
     "grunt-contrib-uglify": "~3.0.1",
     "grunt-exec": "^2.0.0",


### PR DESCRIPTION
Concatenate AMD wrapper code using a new Grunt task into build task.
AMD code is generated on separated files for now, but I think it is retro-compatible.